### PR TITLE
Detect video extension for upload

### DIFF
--- a/peertube-importer.sh
+++ b/peertube-importer.sh
@@ -38,7 +38,7 @@ echo "step 5b"
 
   # 5b) Identify local file & metadata JSON
   VIDEO_ID=$(echo "${VIDEO_URL}" | sed -n 's/.*v=\([^&]*\).*/\1/p')
-  FILE_PATH="${BASE_DIR}/${VIDEO_ID}.webm"
+  FILE_PATH=$(find "${DOWNLOAD_DIR}" -maxdepth 1 -type f -name "${VIDEO_ID}.*" ! -name "*.info.json" | head -n 1)
   INFO_JSON="${DOWNLOAD_DIR}/${VIDEO_ID}.info.json"
 
   # 5c) Extract title & description


### PR DESCRIPTION
## Summary
- Detect actual downloaded video file extension instead of assuming `.webm`

## Testing
- `bash -n peertube-importer.sh`
- `apt-get update` (fails: repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_6894520694388325809f19ed10fd1fd9