### PR TITLE
Add download and upload only modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # peertube-importer
 Import videos from Youtube to Peertube using yt-dlp and peertube-cli.
 
+## Usage
+
+```
+./peertube-importer.sh [--download-only|--upload-only] <channel_url>
+```
+
+Use `--download-only` to fetch videos and metadata without uploading them to
+PeerTube. Use `--upload-only` to upload previously downloaded videos located in
+`yt_downloads`.
+
 ## Configuration
-Copy `sample.env` to `.env` and set `BASE_DIR`, `PEERTUBE_URL`, `PEERTUBE_USER` and `PEERTUBE_PASS` before running the script.
+Copy `sample.env` to `.env` and set `BASE_DIR`, `PEERTUBE_URL`, `PEERTUBE_USER`
+and `PEERTUBE_PASS` before running the script. The PeerTube variables are only
+required when uploading.


### PR DESCRIPTION
## Summary
- allow running downloader or uploader independently via `--download-only` and `--upload-only`
- avoid requiring PeerTube credentials when only downloading
- document new flags and usage

## Testing
- `bash -n peertube-importer.sh`
- `./peertube-importer.sh --help`
- `shellcheck peertube-importer.sh` *(fails: command not found)*
- `sudo apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68945d430e6883259b630a6c2720676c