### PR TITLE
Track uploaded videos to avoid reuploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Use `--download-only` to fetch videos and metadata without uploading them to
 PeerTube. Use `--upload-only` to upload previously downloaded videos located in
 `yt_downloads`.
 
+Uploaded video IDs are tracked in `uploaded.txt`. Videos listed in this file
+are skipped on subsequent runs to avoid re-uploading.
+
 ## Configuration
 Copy `sample.env` to `.env` and set `BASE_DIR`, `PEERTUBE_URL`, `PEERTUBE_USER`
 and `PEERTUBE_PASS` before running the script. The PeerTube variables are only

--- a/peertube-importer.sh
+++ b/peertube-importer.sh
@@ -69,7 +69,9 @@ fi
 # 2) Local dirs & archive
 DOWNLOAD_DIR="./yt_downloads"
 ARCHIVE_FILE="./yt-dlp-archive.txt"
+UPLOAD_ARCHIVE_FILE="./uploaded.txt"
 mkdir -p "${DOWNLOAD_DIR}"
+touch "${UPLOAD_ARCHIVE_FILE}"
 
 # 3) (Optional) authenticate once so future 'upload' calls omit creds
 if [[ "$DOWNLOAD_ONLY" == false ]]; then
@@ -92,6 +94,10 @@ fi
 # 5) Loop through each video
 upload_video() {
   local vid="$1"
+  if grep -Fxq "$vid" "${UPLOAD_ARCHIVE_FILE}"; then
+    echo "Skipping already uploaded video ${vid}"
+    return
+  fi
   local file_path info_json title description
   file_path=$(find "${DOWNLOAD_DIR}" -maxdepth 1 -type f -name "${vid}.*" ! -name "*.info.json" | head -n 1)
   info_json="${DOWNLOAD_DIR}/${vid}.info.json"
@@ -104,6 +110,7 @@ upload_video() {
     --password "${PEERTUBE_PASS}" \
     --video-name "${title}" \
     --video-description "${description}"  # :contentReference[oaicite:3]{index=3}
+  echo "${vid}" >> "${UPLOAD_ARCHIVE_FILE}"
 }
 
 if [[ "$UPLOAD_ONLY" == true ]]; then


### PR DESCRIPTION
## Summary
- Add uploaded.txt archive tracking to skip videos that were already sent to PeerTube
- Document upload tracking in README

## Testing
- `bash -n peertube-importer.sh`
- `shellcheck peertube-importer.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68949c5542b083259ecbcf00317627ff