### PR TITLE
Use archive file for upload-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Import videos from Youtube to Peertube using yt-dlp and peertube-cli.
 ```
 
 Use `--download-only` to fetch videos and metadata without uploading them to
-PeerTube. Use `--upload-only` to upload previously downloaded videos located in
-`yt_downloads`.
+PeerTube. Use `--upload-only` to upload videos whose IDs are listed in
+`yt-dlp-archive.txt` (lines like `youtube <video_id>`) and whose files and
+metadata reside in `yt_downloads`.
 
 Uploaded video IDs are tracked in `uploaded.txt`. Videos listed in this file
 are skipped on subsequent runs to avoid re-uploading.

--- a/peertube-importer.sh
+++ b/peertube-importer.sh
@@ -71,7 +71,7 @@ DOWNLOAD_DIR="./yt_downloads"
 ARCHIVE_FILE="./yt-dlp-archive.txt"
 UPLOAD_ARCHIVE_FILE="./uploaded.txt"
 mkdir -p "${DOWNLOAD_DIR}"
-touch "${UPLOAD_ARCHIVE_FILE}"
+touch "${ARCHIVE_FILE}" "${UPLOAD_ARCHIVE_FILE}"
 
 # 3) (Optional) authenticate once so future 'upload' calls omit creds
 if [[ "$DOWNLOAD_ONLY" == false ]]; then
@@ -114,8 +114,13 @@ upload_video() {
 }
 
 if [[ "$UPLOAD_ONLY" == true ]]; then
-  for info in "${DOWNLOAD_DIR}"/*.info.json; do
-    vid=$(basename "${info}" .info.json)
+  if [[ ! -f "${ARCHIVE_FILE}" ]]; then
+    echo "Error: archive file ${ARCHIVE_FILE} not found."
+    exit 1
+  fi
+  # Extract video IDs from lines like "youtube <id>" in the archive
+  mapfile -t ARCHIVE_VIDS < <(awk '$1 == "youtube" {print $2}' "${ARCHIVE_FILE}")
+  for vid in "${ARCHIVE_VIDS[@]}"; do
     upload_video "${vid}"
   done
 else


### PR DESCRIPTION
## Summary
- Load video IDs from yt-dlp archive when running in upload-only mode
- Document archive usage for uploads

## Testing
- `bash -n peertube-importer.sh`
- `shellcheck peertube-importer.sh` *(fails: command not found, installation attempts unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68959d5dac108325abb67b7fa9e31b2d