### PR TITLE
Use absolute file path for uploads

### DIFF
--- a/peertube-importer.sh
+++ b/peertube-importer.sh
@@ -100,6 +100,7 @@ upload_video() {
   fi
   local file_path info_json title description
   file_path=$(find "${DOWNLOAD_DIR}" -maxdepth 1 -type f -name "${vid}.*" ! -name "*.info.json" | head -n 1)
+  file_path=$(realpath "${file_path}")
   info_json="${DOWNLOAD_DIR}/${vid}.info.json"
   title=$(jq -r '.title' < "${info_json}")
   description=$(jq -r '.description' < "${info_json}")


### PR DESCRIPTION
## Summary
- resolve local video path to an absolute path before uploading

## Testing
- `bash -n peertube-importer.sh`
- `./peertube-importer.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_6895a21a9ed08325b3dea06d04997b4a