### PR TITLE
Show YouTube ID during upload

### DIFF
--- a/peertube-importer.sh
+++ b/peertube-importer.sh
@@ -104,6 +104,7 @@ upload_video() {
   info_json="${DOWNLOAD_DIR}/${vid}.info.json"
   title=$(jq -r '.title' < "${info_json}")
   description=$(jq -r '.description' < "${info_json}")
+  echo "Uploading ${title} (YouTube ID: ${vid})"
   peertube-cli upload \
     --file "${file_path}" \
     --url "${PEERTUBE_URL}" \


### PR DESCRIPTION
## Summary
- Display YouTube video ID when uploading videos to PeerTube

## Testing
- `bash -n peertube-importer.sh`
- `shellcheck peertube-importer.sh` *(fails: command not found)*
- `apt-get install -y shellcheck` *(fails: Unable to locate package shellcheck)*


------
https://chatgpt.com/codex/tasks/task_e_6895a40e7e8883259ee63d91bd307c9a