### PR TITLE
Add optional Firefox cookies for yt-dlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ are skipped on subsequent runs to avoid re-uploading.
 
 ## Configuration
 Copy `sample.env` to `.env` and set `BASE_DIR`, `PEERTUBE_URL`, `PEERTUBE_USER`
-and `PEERTUBE_PASS` before running the script. The PeerTube variables are only
-required when uploading.
+and `PEERTUBE_PASS` before running the script. Set
+`USE_FIREFOX_COOKIES=true` if yt-dlp should use Firefox browser cookies for
+authenticated downloads. The PeerTube variables are only required when uploading.

--- a/sample.env
+++ b/sample.env
@@ -3,3 +3,5 @@ BASE_DIR="/absolute/path/to/video/files"
 PEERTUBE_URL="https://your.peertube.instance"
 PEERTUBE_USER="your_username"
 PEERTUBE_PASS="your_password"
+# Set to true to have yt-dlp use cookies from Firefox
+USE_FIREFOX_COOKIES="false"


### PR DESCRIPTION
## Summary
- allow enabling yt-dlp Firefox browser cookies via `USE_FIREFOX_COOKIES`
- document the new env var in sample.env and README

## Testing
- `bash -n peertube-importer.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896e7d2a4308325a39140716ab40acd