### PR TITLE
Record PeerTube IDs for uploaded videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ script downloads it and sets it on the PeerTube upload.
 Uploaded video IDs are tracked in `uploaded.txt`. Videos listed in this file
 are skipped on subsequent runs to avoid re-uploading.
 
+Each successful upload is also recorded in `uploaded-map.txt` as a mapping
+between the YouTube video ID and the corresponding PeerTube video ID. This
+file can be used later to perform actions like setting a new thumbnail for a
+specific upload.
+
 ## Configuration
 Copy `sample.env` to `.env` and set `BASE_DIR`, `PEERTUBE_URL`, `PEERTUBE_USER`
 and `PEERTUBE_PASS` before running the script. Set


### PR DESCRIPTION
## Summary
- Track YouTube -> PeerTube ID mapping in `uploaded-map.txt`
- Capture upload response and store associated PeerTube video ID
- Document new mapping file in README

## Testing
- `bash -n peertube-importer.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896e92fc29c8325a7af2af951e99d68