### PR TITLE
Remove deprecated --json flags from peertube-cli calls

### DIFF
--- a/peertube-importer.sh
+++ b/peertube-importer.sh
@@ -114,7 +114,7 @@ sync_metadata() {
     thumb_path=$(realpath "${thumb_path}")
   fi
   remote_json=$(peertube-cli video get --id "${peertube_id}" --url "${PEERTUBE_URL}" \
-    --username "${PEERTUBE_USER}" --password "${PEERTUBE_PASS}" --json 2>/dev/null || true)
+    --username "${PEERTUBE_USER}" --password "${PEERTUBE_PASS}" 2>/dev/null || true)
   remote_title=$(jq -r '.name // .title // empty' <<<"${remote_json}")
   remote_description=$(jq -r '.description // empty' <<<"${remote_json}")
   remote_thumb=$(jq -r '.thumbnailPath // .thumbnailUrl // empty' <<<"${remote_json}")
@@ -147,7 +147,6 @@ sync_metadata() {
     fi
   fi
   if [[ "${update}" == true ]]; then
-    update_args+=(--json)
     echo "Updating metadata for ${vid} (${peertube_id})"
     "${update_args[@]}"
   else
@@ -195,7 +194,6 @@ upload_video() {
     --password "${PEERTUBE_PASS}"
     --video-name "${title}"
     --video-description "${description}"
-    --json
   )
   if [[ -n "${thumb_path}" ]]; then
     upload_args+=(--thumbnail-file "${thumb_path}")


### PR DESCRIPTION
## Summary
- fix peertube-importer script to work with newer peertube-cli versions by removing `--json` options

## Testing
- `bash -n peertube-importer.sh`
- `shellcheck peertube-importer.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896f85403f88325a33d6f4d91d8a02a