### PR TITLE
Remove API publish date logic and add DB script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,17 @@ server and appends any matches to `uploaded-map.txt` as `<youtube_id>
 Copy `sample.env` to `.env` and set `BASE_DIR`, `PEERTUBE_URL`, `PEERTUBE_USER`
 and `PEERTUBE_PASS` before running the script. Set
 `USE_FIREFOX_COOKIES=true` if yt-dlp should use Firefox browser cookies for
-authenticated downloads. Set `MATCH_UPLOAD_DATE=true` to make the PeerTube
-publication date match the original YouTube upload date using the REST API
-(requires administrator access on the PeerTube instance). The PeerTube variables
-are only required when uploading.
+authenticated downloads. The PeerTube variables are only required when
+uploading. `set_publish_date.py` uses the standard PostgreSQL environment
+variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`) to connect
+directly to the PeerTube database and update publication dates.
+
+## Setting publication dates
+
+After uploading videos, run `set_publish_date.py` to update the PeerTube
+`published_at` field based on the original YouTube upload dates stored in the
+`yt_downloads/*.info.json` files and the mappings in `uploaded-map.txt`.
+
+```bash
+./set_publish_date.py
+```

--- a/sample.env
+++ b/sample.env
@@ -5,6 +5,9 @@ PEERTUBE_USER="your_username"
 PEERTUBE_PASS="your_password"
 # Set to true to have yt-dlp use cookies from Firefox
 USE_FIREFOX_COOKIES="false"
-# Set to true to make PeerTube publication date match YouTube's upload date via REST API
-# Requires administrator access on the PeerTube instance
-MATCH_UPLOAD_DATE="false"
+# PostgreSQL connection info for set_publish_date.py
+PGHOST="localhost"
+PGPORT="5432"
+PGDATABASE="peertube"
+PGUSER="peertube"
+PGPASSWORD="peertube_password"

--- a/set_publish_date.py
+++ b/set_publish_date.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Set PeerTube publication dates directly via PostgreSQL.
+
+Reads `uploaded-map.txt` for mappings between YouTube IDs and PeerTube video
+IDs, looks up the original YouTube upload dates from
+`yt_downloads/<youtube_id>.info.json`, and updates the `published_at` column in
+the PeerTube `video` table accordingly. Connection parameters are taken from the
+standard PostgreSQL environment variables (`PGHOST`, `PGPORT`, `PGDATABASE`,
+`PGUSER`, `PGPASSWORD`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+from datetime import datetime, timezone
+
+import psycopg2
+
+DOWNLOAD_DIR = pathlib.Path("./yt_downloads")
+MAP_FILE = pathlib.Path("./uploaded-map.txt")
+
+
+def read_upload_date(yt_id: str) -> datetime | None:
+    """Return the upload date from the video's info JSON, if available."""
+    info_path = DOWNLOAD_DIR / f"{yt_id}.info.json"
+    if not info_path.exists():
+        return None
+    try:
+        with info_path.open() as f:
+            data = json.load(f)
+    except Exception:
+        return None
+    date_str = data.get("upload_date")
+    if not date_str:
+        return None
+    try:
+        dt = datetime.strptime(date_str, "%Y%m%d").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+    return dt
+
+
+def main() -> None:
+    conn = psycopg2.connect(
+        host=os.getenv("PGHOST", "localhost"),
+        port=os.getenv("PGPORT", "5432"),
+        dbname=os.getenv("PGDATABASE", "peertube"),
+        user=os.getenv("PGUSER"),
+        password=os.getenv("PGPASSWORD"),
+    )
+    with conn, conn.cursor() as cur:
+        with MAP_FILE.open() as f:
+            for line in f:
+                parts = line.strip().split()
+                if len(parts) != 2:
+                    continue
+                yt_id, pt_id = parts
+                dt = read_upload_date(yt_id)
+                if not dt:
+                    continue
+                cur.execute(
+                    "UPDATE video SET published_at = %s WHERE uuid::text = %s OR short_uuid = %s OR id::text = %s",
+                    (dt, pt_id, pt_id, pt_id),
+                )
+    print("Publication dates updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- drop REST API calls for setting publish dates
- add `set_publish_date.py` to update `published_at` directly in PostgreSQL
- document Postgres connection variables and usage

## Testing
- `bash -n peertube-importer.sh`
- `python -m py_compile match_peertube_videos.py set_publish_date.py`


------
https://chatgpt.com/codex/tasks/task_e_689702de0a308325b9d1dc249d1692f8