### PR TITLE
Load DB credentials from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Copy `sample.env` to `.env` and set `BASE_DIR`, `PEERTUBE_URL`, `PEERTUBE_USER`
 and `PEERTUBE_PASS` before running the script. Set
 `USE_FIREFOX_COOKIES=true` if yt-dlp should use Firefox browser cookies for
 authenticated downloads. The PeerTube variables are only required when
-uploading. `set_publish_date.py` uses the standard PostgreSQL environment
-variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`) to connect
-directly to the PeerTube database and update publication dates.
+uploading. `set_publish_date.py` reads PostgreSQL connection settings from the
+`.env` file or the standard environment variables (`PGHOST`, `PGPORT`,
+`PGDATABASE`, `PGUSER`, `PGPASSWORD`) to connect directly to the PeerTube
+database and update publication dates.
 
 ## Setting publication dates
 


### PR DESCRIPTION
## Summary
- ensure `set_publish_date.py` reads PostgreSQL connection settings from a `.env` file before falling back to environment variables
- document `.env` support in README

## Testing
- `python -m py_compile set_publish_date.py match_peertube_videos.py`
- `python set_publish_date.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `pip install psycopg2-binary` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68976b359a488325bb07c9011eae9cbf