### PR TITLE
Fix yt_id extraction for info.json files

### DIFF
--- a/match_peertube_videos.py
+++ b/match_peertube_videos.py
@@ -36,7 +36,7 @@ def load_env(path: str = ".env") -> dict:
 def build_title_map(download_dir: pathlib.Path) -> dict:
     title_map = {}
     for info in download_dir.glob("*.info.json"):
-        yt_id = info.stem
+        yt_id = info.name.removesuffix(".info.json")
         try:
             with info.open() as f:
                 data = json.load(f)


### PR DESCRIPTION
## Summary
- Ensure match_peertube_videos.py strips `.info` from video IDs when reading `*.info.json` files

## Testing
- `python -m py_compile match_peertube_videos.py`
- `python - <<'PY'
import match_peertube_videos as m
from pathlib import Path
import json, os, shutil
os.makedirs('yt_downloads', exist_ok=True)
with open('yt_downloads/abcd1234.info.json','w') as f: json.dump({'title':'Test Video'}, f)
print(m.build_title_map(Path('yt_downloads')))
shutil.rmtree('yt_downloads')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68983340a7548325b14743e2209f4b28