### PR TITLE
Notify when no new PeerTube videos mapped

### DIFF
--- a/match_peertube_videos.py
+++ b/match_peertube_videos.py
@@ -120,6 +120,7 @@ def main() -> None:
     videos = fetch_peertube_videos(pt_url, token) if pt_url else []
 
     with MAP_FILE.open("a") as out:
+        mapped_any = False
         for vid in videos:
             pt_id = vid.get("uuid") or vid.get("shortUUID") or str(vid.get("id"))
             yt_id = match_title(vid.get("name", ""), title_map)
@@ -127,7 +128,10 @@ def main() -> None:
                 continue
             out.write(f"{yt_id} {pt_id}\n")
             existing_map[yt_id] = pt_id
+            mapped_any = True
             print(f"Mapped {yt_id} -> {pt_id}")
+        if not mapped_any:
+            print("No new videos were added.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log when matching finds no new PeerTube videos to add

## Testing
- `python -m py_compile match_peertube_videos.py`
- `python match_peertube_videos.py`


------
https://chatgpt.com/codex/tasks/task_e_68983537c9ec8325b16f301992e1d9c6