### PR TITLE
fix: correctly quote peertube-cli arguments

### DIFF
--- a/peertube-importer.sh
+++ b/peertube-importer.sh
@@ -286,7 +286,7 @@ upload_video() {
   if [[ -n "${thumb_path}" ]]; then
     upload_args+=(--thumbnail "${thumb_path}")
   fi
-  upload_json=$(${upload_args[@]})
+  upload_json=$("${upload_args[@]}")
   echo "${upload_json}"
   peertube_id=$(jq -r '.video.uuid // .video.shortUUID // .video.id // empty' <<<"${upload_json}" 2>/dev/null || true)
   if [[ -n "${peertube_id}" ]]; then


### PR DESCRIPTION
## Summary
- ensure peertube-cli upload arguments are quoted to preserve spaces

## Testing
- `bash -n peertube-importer.sh`
- `shellcheck peertube-importer.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68990951c6e48325a3acb9539dfb3c1b