### PR TITLE
Use YouTube timestamp for publish date updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ publication dates.
 ## Setting publication dates
 
 After uploading videos, run `set_publish_date.py` to update the PeerTube
-`publishedAt` field based on the original YouTube upload dates stored in the
+`publishedAt` field based on the original YouTube timestamps stored in the
 `yt_downloads/*.info.json` files and the mappings in `uploaded-map.txt`.
 
 ```bash


### PR DESCRIPTION
## Summary
- parse the `timestamp` field from YouTube info JSON when setting PeerTube `publishedAt`
- document that publish dates are derived from YouTube timestamps

## Testing
- `python -m py_compile set_publish_date.py`


------
https://chatgpt.com/codex/tasks/task_e_689d78be799883258a455a8ae5ad75cb