### PR TITLE
Use timestamp from YouTube JSON for publish date

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ database and update publication dates.
 ## Setting publication dates
 
 After uploading videos, run `set_publish_date.py` to update the PeerTube
-`published_at` field based on the original YouTube upload dates stored in the
+`published_at` field using the YouTube `timestamp` value stored in the
 `yt_downloads/*.info.json` files and the mappings in `uploaded-map.txt`.
 
 ```bash


### PR DESCRIPTION
## Summary
- parse YouTube JSON `timestamp` to set PeerTube publish dates
- update docs to mention timestamp usage

## Testing
- `python -m py_compile set_publish_date.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_689d931f398c83258ebda2029fef2d61